### PR TITLE
docs: document build prerequisites for Ubuntu/Debian

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,16 @@ This file provides guidance for AI agents working on the **symfonion** codebase 
 
 ## Build & Test
 
+### Prerequisites (Ubuntu/Debian)
+
+```bash
+sudo apt install maven ruby-rubygems openjdk-21-jdk
+# Then set OpenJDK 21 as default:
+sudo update-alternatives --config java   # choose openjdk-21 from the list
+```
+
+### Commands
+
 ```bash
 # Compile and run all tests
 mvn -B package

--- a/README.md
+++ b/README.md
@@ -28,6 +28,29 @@ $ symfonion
 Windows is not supported at this time. The distribution does not include a `.bat` launcher.
 Windows users may run Symfonion under WSL (Windows Subsystem for Linux) by following the Linux instructions above.
 
+# Building from Source
+
+## Prerequisites
+
+Install the following on Ubuntu/Debian before building:
+
+```bash
+sudo apt install maven ruby-rubygems openjdk-21-jdk
+```
+
+After installing OpenJDK 21, make it the default JVM:
+
+```bash
+sudo update-alternatives --config java
+# Choose the entry for openjdk-21 from the list
+```
+
+## Build
+
+```bash
+mvn -B package
+```
+
 # How to run Symfonion #
 By typing a command line below, ```symfonion``` will compile the given JSON file and play it.
 


### PR DESCRIPTION
## Summary

- Adds `apt install` commands for `maven`, `ruby-rubygems`, and `openjdk-21-jdk`
- Documents the `update-alternatives --config java` step to set OpenJDK 21 as the default JVM
- Applied to both `README.md` (new "Building from Source" section) and `AGENTS.md` (under Build & Test)

## Test plan

- [ ] Verify commands work on a fresh Ubuntu/Debian install

🤖 Generated with [Claude Code](https://claude.com/claude-code)