### PR TITLE
docs(test): document and verify pickup notation (anacrusis) via `|`

### DIFF
--- a/src/site/asciidoc/SYNTAX.adoc
+++ b/src/site/asciidoc/SYNTAX.adoc
@@ -258,6 +258,38 @@ For example, strings below are valid for this attribute.
                           // You can concatenate strokes by using semi colons.
 ----
     
+==== Pickup notation (anacrusis)
+
+The `|` character in a body string marks a *barline*: notes written **before** `|` are *pickup notes* (also called an *anacrusis* in classical music theory) and play in the tail of the **preceding bar**, overlaid on top of its existing content.
+Notes written **after** `|` are the main body of the current bar.
+
+[source, json]
+----
+{ "beats": "4/4", "parts": [{"name": "piano", "body": "r4;r4;r4;r4"}] },
+{ "beats": "4/4", "parts": [{"name": "piano", "body": "E8|E4;D4;C4;r4"}] }
+----
+
+In this example the `E8` pickup plays in the last 1/8 of the preceding 4/4 bar, and `E4;D4;C4;r4` fills the current bar.
+This is more readable than spelling the pickup out explicitly in the previous bar:
+
+[source, json]
+----
+{ "beats": "4/4", "parts": [{"name": "piano", "body": "r2;r4;r8;E8"}] },
+{ "beats": "4/4", "parts": [{"name": "piano", "body": "E4;D4;C4;r4"}] }
+----
+
+Consecutive bars with pickup notation chain naturally — each bar's pickup overlays the tail of the bar that precedes it:
+
+[source, json]
+----
+{ "beats": "4/4", "parts": [{"name": "piano", "body": "r4;r4;r4;r4"}] },
+{ "beats": "4/4", "parts": [{"name": "piano", "body": "E8|E4;D4;C4;r4"}] },
+{ "beats": "4/4", "parts": [{"name": "piano", "body": "E8|E4;D4;C4;r4"}] }
+----
+
+NOTE: Pickup notes require a preceding bar in the sequence.
+If a pickup appears in the very first bar of the sequence it will be placed before tick 0 and may not play.
+
 ==== Non-note messages
 
 Some of non-note messages, for example 'volume', can have arrays as their values.

--- a/src/test/java/com/github/dakusui/symfonion/tests/MidiCompilerTest.java
+++ b/src/test/java/com/github/dakusui/symfonion/tests/MidiCompilerTest.java
@@ -15,13 +15,19 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import com.google.gson.JsonObject;
+import javax.sound.midi.MidiEvent;
+import javax.sound.midi.Sequence;
 import javax.sound.midi.Track;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 
 import static com.github.dakusui.symfonion.testutils.SymfonionTestCase.createNegativeTestCase;
 import static com.github.dakusui.symfonion.testutils.SymfonionTestCase.createPositiveTestCase;
+import static com.github.dakusui.symfonion.testutils.SymfonionTestUtils.compileJsonObject;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static com.github.dakusui.symfonion.testutils.json.SymfonionJsonTestUtils.sixteenBeatsGrooveFlat;
 import static com.github.dakusui.testutils.json.JsonTestUtils.*;
 import static com.github.dakusui.testutils.midi.Controls.VOLUME;
@@ -259,6 +265,41 @@ public class MidiCompilerTest extends TestBase {
                 toStreamBy(midiMessageStream(isNoteOff())).checkCount(isEqualTo(2L))))
                         );
 
+  }
+
+  /**
+   * Verifies pickup notation: notes before `|` in a body string play in the tail
+   * of the preceding bar. With a 4/4 bar (384 ticks) and an E8 pickup (48 ticks),
+   * the pickup NoteOn must land at tick 336 = 384 - 48.
+   */
+  @org.junit.jupiter.api.Test
+  void pickupNotation_noteOnAtCorrectTick() throws Exception {
+    JsonObject song = object(
+        $("settings", object()),
+        $("parts", object($("piano", object($("channel", json(0)), $("port", json("port1")))))),
+        $("sequence", array(
+            merge(object($("beats", json("4/4"))),
+                  object($("parts", array(merge(object($("name", json("piano"))),
+                                               object($("body", json("r4;r4;r4;r4")))))))),
+            merge(object($("beats", json("4/4"))),
+                  object($("parts", array(merge(object($("name", json("piano"))),
+                                               object($("body", json("E8|E4;D4;C4;r4")))))))))));;
+
+    Map<String, Sequence> result = compileJsonObject(song);
+    Track track = result.get("port1").getTracks()[0];
+
+    long pickupTick = -1;
+    for (int i = 0; i < track.size(); i++) {
+      MidiEvent ev = track.get(i);
+      byte[] msg = ev.getMessage().getMessage();
+      boolean isNoteOn = (msg[0] & 0xf0) == 0x90;
+      boolean isE = msg[1] == 64; // E3 = MIDI key 64
+      if (isNoteOn && isE) {
+        pickupTick = ev.getTick();
+        break;
+      }
+    }
+    assertEquals(336L, pickupTick, "Pickup E8 note-on should land at tick 336 (last 1/8 of the preceding 4/4 bar)");
   }
 
   public static List<SymfonionTestCase> negativeTestCases() {


### PR DESCRIPTION
## Summary

- The `|` barline operator in body strings was already fully implemented but entirely undocumented
- Adds a **"Pickup notation (anacrusis)"** section to `SYNTAX.adoc` explaining the feature, the correct music terminology (pickup / anacrusis — not syncopation), single-bar and chained examples, and a caveat about first-bar usage
- Adds `pickupNotation_noteOnAtCorrectTick()` to `MidiCompilerTest` — compiles a two-bar fixture (`r4;r4;r4;r4` + `E8|E4;D4;C4;r4`) and asserts the pickup E8 note-on lands at tick **336** (= bar1_start 384 − pickup 48)

Closes #99

## Test plan

- [x] `mvn -B test` — 125 tests pass, 0 failures
- [x] New `MidiCompilerTest#pickupNotation_noteOnAtCorrectTick` passes and asserts the correct tick position

🤖 Generated with [Claude Code](https://claude.com/claude-code)