### PR TITLE
feat: YAML input + first-run jq++ toolchain bootstrap in launcher

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,31 @@ src/
 - Tests use **JUnit 5 (Jupiter)**; keep new tests in `src/test/java/…/symfonion/tests/`.
 - For bash scripts, follow the project's shell conventions (see `.claude/skills/symfonion-bash`).
 
+## Directory Layout
+
+```
+symfonion-VERSION/           ← SYMFONION_HOME
+  bin/
+    symfonion                ← CLI launcher (bash); only file shipped in bin/
+  lib/
+    symfonion-VERSION.jar    ← Java core (shipped)
+    yq                       ← YAML→JSON converter  (bootstrapped on first run)
+    jqplusplus               ← jq++ binary          (bootstrapped on first run)
+    jq++                     ← symlink → jqplusplus (created by jqplusplus itself)
+  share/
+    symfonion/
+      prelude/               ← built-in jq++ standard library (shipped, may be empty)
+```
+
+Optional, project-local (alongside the user's song files):
+
+```
+.symfonion/
+  prelude/                   ← project-local jq++ library; higher priority than built-in
+```
+
+`JF_PATH` precedence: `$SYMFONION_PATH` → `.symfonion/prelude` → `share/symfonion/prelude`.
+
 ## Launcher & Preprocessing Pipeline
 
 `bin/symfonion` (and its dev copy `src/main/resources/utils/symfonion`) handles three concerns:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,28 +62,7 @@ src/
 
 ## Directory Layout
 
-```
-symfonion-VERSION/           ← SYMFONION_HOME
-  bin/
-    symfonion                ← CLI launcher (bash); only file shipped in bin/
-  lib/
-    symfonion-VERSION.jar    ← Java core (shipped)
-    yq                       ← YAML→JSON converter  (bootstrapped on first run)
-    jqplusplus               ← jq++ binary          (bootstrapped on first run)
-    jq++                     ← symlink → jqplusplus (created by jqplusplus itself)
-  share/
-    symfonion/
-      prelude/               ← built-in jq++ standard library (shipped, may be empty)
-```
-
-Optional, project-local (alongside the user's song files):
-
-```
-.symfonion/
-  prelude/                   ← project-local jq++ library; higher priority than built-in
-```
-
-`JF_PATH` precedence: `$SYMFONION_PATH` → `.symfonion/prelude` → `share/symfonion/prelude`.
+See [`src/site/asciidoc/INSTALLATION.adoc`](src/site/asciidoc/INSTALLATION.adoc) for the full layout, first-run bootstrap details, and `JF_PATH` precedence.
 
 ## Launcher & Preprocessing Pipeline
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,11 +53,22 @@ src/
 
 ## Key Conventions
 
+- **YAML is the primary user-facing input format.** The `bin/symfonion` launcher transparently converts `.yaml`/`.yml` files through `yq` → `jq++` before passing them to the JAR. Plain `.json` files are passed directly and remain fully supported.
 - **No Windows support** — only Linux/macOS launchers; do not introduce `.bat` scripts.
 - **No dollar-sign prefixes** on JSON/YAML keywords (removed in v3.x).
 - **Java 21** — use modern Java features freely; the CI baseline is JDK 21.
 - Tests use **JUnit 5 (Jupiter)**; keep new tests in `src/test/java/…/symfonion/tests/`.
 - For bash scripts, follow the project's shell conventions (see `.claude/skills/symfonion-bash`).
+
+## Launcher & Preprocessing Pipeline
+
+`bin/symfonion` (and its dev copy `src/main/resources/utils/symfonion`) handles three concerns:
+
+1. **Dependency bootstrap** — on first use, downloads `yq` and installs `jqplusplus` (via `go install`) into `$SYMFONION_HOME/lib/`. Presence of `lib/jq++` (the symlink created by jqplusplus) signals that deps are ready.
+2. **YAML preprocessing** — `.yaml`/`.yml` args are piped through `yq -o=json | jq++` and written to a temp file; the temp path replaces the original arg.
+3. **JF_PATH setup** — builds the search path for `jq++` library files (prelude), respecting `SYMFONION_PATH` → `.symfonion/prelude` → built-in prelude.
+
+Version pins (`yq_version`, `jqplusplus_version`) live at the top of both launcher files and should be bumped together at release time.
 
 ## Release
 

--- a/README.md
+++ b/README.md
@@ -32,14 +32,15 @@ symfonion-VERSION/
       prelude/                  ← built-in jq++ standard library
 ```
 
-On the **first invocation** the launcher downloads and installs two companion tools into `lib/`:
+On the **first invocation** the launcher downloads and installs two companion tools into `lib/symfonion/` (namespaced to avoid conflicts when installing into a shared prefix such as `~/.local`):
 
 ```
 symfonion-VERSION/
   lib/
-    yq                          ← YAML→JSON converter  (downloaded from GitHub releases)
-    jqplusplus                  ← jq++ binary          (installed via go install; requires Go)
-    jq++                        ← symlink → jqplusplus (created by jqplusplus itself)
+    symfonion/
+      yq                        ← YAML→JSON converter  (downloaded from GitHub releases)
+      jqplusplus                ← jq++ binary          (installed via go install; requires Go)
+      jq++                      ← symlink → jqplusplus (created by jqplusplus itself)
 ```
 
 You can also place project-local jq++ library files in `.symfonion/prelude/` alongside your song files; the launcher adds that directory to `JF_PATH` automatically (higher priority than the built-in prelude).

--- a/README.md
+++ b/README.md
@@ -52,13 +52,53 @@ mvn -B package
 ```
 
 # How to run Symfonion #
-By typing a command line below, ```symfonion``` will compile the given JSON file and play it.
+
+Symfonion accepts **YAML** (recommended) or JSON input files.
+The launcher transparently converts `.yaml` / `.yml` files through `yq` and `jq++` before processing.
+Because YAML is a superset of JSON, all existing `.json` files continue to work unchanged.
 
 ```
-$ symfonion -p infile
+$ symfonion -p infile.yaml
 ```
 
-where "infile" is a ```symfonion``` file and it will look like this.
+A symfonion file in YAML (W.A. Mozart, K.311):
+
+```yaml
+parts:
+  pianor:
+    channel: 0
+
+sequence:
+  - parts:
+      - name: pianor
+        body: "r4;B;A;G#;A"
+        length: 16
+    beats: "2/4"
+  - parts:
+      - name: pianor
+        body: "C>8;r8;D>;C>;B;C>;E>8;r8;F>;E>;D#>;E>"
+        length: 16
+    beats: "4/4"
+  - parts:
+      - name: pianor
+        body: "B>;A>;G#>;A>;B>;A>;G#>;A>;C>>4;A>8;C>>8"
+        length: 16
+    beats: "4/4"
+  - parts:
+      - name: pianor
+        body: "B>;F#A>;EG>;F#A>;B>;F#A>;EG>;F#A>"
+        length: 8
+        gate: 0.3
+    beats: "4/4"
+  - parts:
+      - name: pianor
+        body: "B>;F#A;EG>;D#F#>;E4;r4"
+        length: 8
+        gate: 0.3
+    beats: "4/4"
+```
+
+The equivalent JSON form (also accepted):
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -17,6 +17,33 @@ Symfonion is a modern music macro language processor.
 3. Add `symfonion-VERSION/bin/` to your `PATH`.
 4. Done.
 
+### Directory layout
+
+The archive unpacks to a self-contained tree:
+
+```
+symfonion-VERSION/
+  bin/
+    symfonion                   ← CLI launcher (bash)
+  lib/
+    symfonion-VERSION.jar       ← Java core
+  share/
+    symfonion/
+      prelude/                  ← built-in jq++ standard library
+```
+
+On the **first invocation** the launcher downloads and installs two companion tools into `lib/`:
+
+```
+symfonion-VERSION/
+  lib/
+    yq                          ← YAML→JSON converter  (downloaded from GitHub releases)
+    jqplusplus                  ← jq++ binary          (installed via go install; requires Go)
+    jq++                        ← symlink → jqplusplus (created by jqplusplus itself)
+```
+
+You can also place project-local jq++ library files in `.symfonion/prelude/` alongside your song files; the launcher adds that directory to `JF_PATH` automatically (higher priority than the built-in prelude).
+
 You will be able to run ```symfonion``` by typing
 
 ```

--- a/src/main/dist/bin/symfonion
+++ b/src/main/dist/bin/symfonion
@@ -4,7 +4,9 @@
 # Responsibilities:
 #   1. Locate SYMFONION_HOME relative to this script.
 #   2. On first use, install companion tools (yq, jqplusplus / jq++) under
-#      SYMFONION_HOME/lib/. Subsequent invocations skip this step.
+#      SYMFONION_HOME/lib/symfonion/. Using a sub-directory avoids conflicts
+#      when symfonion is unpacked into a shared prefix (e.g. ~/.local) whose
+#      lib/ already contains other tools. Subsequent invocations skip installation.
 #   3. Build JF_PATH so that jq++ can resolve built-in YAML++ files shipped
 #      with SyMFONION (the "prelude" standard-library layer), while still
 #      honouring user- and project-supplied overrides.
@@ -117,27 +119,27 @@ function main() {
   local _symfonion_home
   _symfonion_home="$(realpath "${_scriptdir}/..")"
   local _lib="${_symfonion_home}/lib"
+  local _tools="${_lib}/symfonion"
 
   export JF_PATH
   JF_PATH="$(_build_jf_path "${_symfonion_home}")"
 
-  _ensure_deps "${_lib}"
+  _ensure_deps "${_tools}"
 
   # Preprocess .yaml / .yml arguments: convert YAML → JSON via yq, then
   # resolve jq++ directives ($extends, $includes, etc.) via jq++.
   local -a _args=()
-  local _arg _tmp
+  local _arg _yq_tmp _tmp
   for _arg in "${@}"; do
     if [[ "${_arg}" =~ \.(yaml|yml)$ ]] && [[ -f "${_arg}" ]]; then
       # Two temp files: yq writes JSON to the first; jq++ reads it by path
       # (passing a file argument avoids the no-args symlink-creation branch
       # that jq++ enters when invoked without positional arguments).
-      local _yq_tmp _tmp
       _yq_tmp="$(mktemp /tmp/symfonion-yq-XXXXXX.json)"
       _tmp="$(mktemp /tmp/symfonion-XXXXXX.json)"
       symfonion_cleanup_files+=("${_yq_tmp}" "${_tmp}")
-      "${_lib}/yq" -o=json "${_arg}" > "${_yq_tmp}"
-      "${_lib}/jq++" "${_yq_tmp}" > "${_tmp}"
+      "${_tools}/yq" -o=json "${_arg}" > "${_yq_tmp}"
+      "${_tools}/jq++" "${_yq_tmp}" > "${_tmp}"
       _args+=("${_tmp}")
     else
       _args+=("${_arg}")
@@ -149,9 +151,9 @@ function main() {
     trap 'rm -f "${symfonion_cleanup_files[@]}"' EXIT
     # ${project.version} is substituted by Maven resource filtering at assembly time
     # (see <filtered>true</filtered> in src/assembly/bin.xml).
-    java -jar "${_symfonion_home}/lib/symfonion-${project.version}.jar" "${_args[@]}"
+    java -jar "${_lib}/symfonion-${project.version}.jar" "${_args[@]}"
   else
-    exec java -jar "${_symfonion_home}/lib/symfonion-${project.version}.jar" "${_args[@]}"
+    exec java -jar "${_lib}/symfonion-${project.version}.jar" "${_args[@]}"
   fi
 }
 

--- a/src/main/dist/bin/symfonion
+++ b/src/main/dist/bin/symfonion
@@ -3,10 +3,15 @@
 #
 # Responsibilities:
 #   1. Locate SYMFONION_HOME relative to this script.
-#   2. Build JF_PATH so that jq++ can resolve built-in YAML++ files shipped
+#   2. On first use, install companion tools (yq, jqplusplus / jq++) under
+#      SYMFONION_HOME/lib/. Subsequent invocations skip this step.
+#   3. Build JF_PATH so that jq++ can resolve built-in YAML++ files shipped
 #      with SyMFONION (the "prelude" standard-library layer), while still
 #      honouring user- and project-supplied overrides.
-#   3. Launch the SyMFONION Java core with all arguments forwarded.
+#   4. For .yaml / .yml input files, run the preprocessing pipeline:
+#        yq -o=json <file>  |  jq++  >  <tmp>.json  →  symfonion JAR
+#      Plain .json files are passed directly to the JAR.
+#   5. Launch the SyMFONION Java core with all arguments forwarded.
 #
 # JF_PATH precedence (highest → lowest):
 #   1. User-specified paths  — $SYMFONION_PATH set before invoking symfonion
@@ -14,6 +19,16 @@
 #   3. Built-in prelude      — $SYMFONION_HOME/share/symfonion/prelude
 
 set -eu -o pipefail -o errtrace
+
+# Version pins for companion tools installed on first use.
+# Bump these when releasing a new symfonion version.
+yq_version="4.44.3"
+jqplusplus_version="latest"
+
+# Temp files created during YAML preprocessing; populated inside main,
+# referenced from the EXIT trap (must be global — local vars are out of
+# scope by the time the EXIT trap fires).
+symfonion_cleanup_files=()
 
 # --- definitions ---
 
@@ -41,18 +56,103 @@ function _build_jf_path() {
   printf '%s' "${_path}"
 }
 
+function _detect_platform() {
+  local _os _arch
+  case "$(uname -s)" in
+    Linux)  _os="linux"  ;;
+    Darwin) _os="darwin" ;;
+    *)
+      printf 'symfonion: unsupported OS: %s\n' "$(uname -s)" >&2
+      return 1
+      ;;
+  esac
+  case "$(uname -m)" in
+    x86_64)        _arch="amd64" ;;
+    arm64|aarch64) _arch="arm64" ;;
+    *)
+      printf 'symfonion: unsupported architecture: %s\n' "$(uname -m)" >&2
+      return 1
+      ;;
+  esac
+  printf '%s_%s' "${_os}" "${_arch}"
+}
+
+function _install_yq() {
+  local _dest="${1}"
+  local _platform
+  _platform="$(_detect_platform)"
+  printf 'symfonion: installing yq %s for %s ...\n' "${yq_version}" "${_platform}" >&2
+  curl -fsSL \
+    "https://github.com/mikefarah/yq/releases/download/v${yq_version}/yq_${_platform}" \
+    -o "${_dest}"
+  chmod +x "${_dest}"
+  printf 'symfonion: yq installed at %s\n' "${_dest}" >&2
+}
+
+function _install_jqplusplus() {
+  local _lib="${1}"
+  printf 'symfonion: installing jqplusplus (%s) ...\n' "${jqplusplus_version}" >&2
+  command -v go >/dev/null 2>&1 || {
+    printf 'symfonion: error: jqplusplus requires the Go toolchain.\n' >&2
+    printf '  Install Go from https://go.dev/dl/ then re-run symfonion.\n' >&2
+    return 1
+  }
+  go install "github.com/dakusui/jqplusplus/cmd/jqplusplus@${jqplusplus_version}"
+  cp "$(go env GOPATH)/bin/jqplusplus" "${_lib}/jqplusplus"
+  chmod +x "${_lib}/jqplusplus"
+  # Invoking jqplusplus with no arguments creates the jq++ symlink next to it.
+  "${_lib}/jqplusplus"
+  printf 'symfonion: jqplusplus installed at %s\n' "${_lib}/jq++" >&2
+}
+
+function _ensure_deps() {
+  local _lib="${1}"
+  [[ -x "${_lib}/yq" ]]   || _install_yq "${_lib}/yq"
+  [[ -x "${_lib}/jq++" ]] || _install_jqplusplus "${_lib}"
+}
+
 function main() {
   local _scriptdir
   _scriptdir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
   local _symfonion_home
   _symfonion_home="$(realpath "${_scriptdir}/..")"
+  local _lib="${_symfonion_home}/lib"
 
   export JF_PATH
   JF_PATH="$(_build_jf_path "${_symfonion_home}")"
 
-  # ${project.version} is substituted by Maven resource filtering at assembly time
-  # (see <filtered>true</filtered> in src/assembly/bin.xml).
-  exec java -jar "${_symfonion_home}/lib/symfonion-${project.version}.jar" "${@}"
+  _ensure_deps "${_lib}"
+
+  # Preprocess .yaml / .yml arguments: convert YAML → JSON via yq, then
+  # resolve jq++ directives ($extends, $includes, etc.) via jq++.
+  local -a _args=()
+  local _arg _tmp
+  for _arg in "${@}"; do
+    if [[ "${_arg}" =~ \.(yaml|yml)$ ]] && [[ -f "${_arg}" ]]; then
+      # Two temp files: yq writes JSON to the first; jq++ reads it by path
+      # (passing a file argument avoids the no-args symlink-creation branch
+      # that jq++ enters when invoked without positional arguments).
+      local _yq_tmp _tmp
+      _yq_tmp="$(mktemp /tmp/symfonion-yq-XXXXXX.json)"
+      _tmp="$(mktemp /tmp/symfonion-XXXXXX.json)"
+      symfonion_cleanup_files+=("${_yq_tmp}" "${_tmp}")
+      "${_lib}/yq" -o=json "${_arg}" > "${_yq_tmp}"
+      "${_lib}/jq++" "${_yq_tmp}" > "${_tmp}"
+      _args+=("${_tmp}")
+    else
+      _args+=("${_arg}")
+    fi
+  done
+
+  if [[ ${#symfonion_cleanup_files[@]} -gt 0 ]]; then
+    # Cannot use exec: the EXIT trap must fire to remove temp files.
+    trap 'rm -f "${symfonion_cleanup_files[@]}"' EXIT
+    # ${project.version} is substituted by Maven resource filtering at assembly time
+    # (see <filtered>true</filtered> in src/assembly/bin.xml).
+    java -jar "${_symfonion_home}/lib/symfonion-${project.version}.jar" "${_args[@]}"
+  else
+    exec java -jar "${_symfonion_home}/lib/symfonion-${project.version}.jar" "${_args[@]}"
+  fi
 }
 
 # --- entry point ---

--- a/src/main/resources/utils/symfonion
+++ b/src/main/resources/utils/symfonion
@@ -2,8 +2,10 @@
 # symfonion — CLI launcher for SyMFONION (development / unversioned build)
 #
 # On the first invocation, companion tools (yq, jqplusplus / jq++) are
-# downloaded or built and cached under SYMFONION_HOME/lib/.  Subsequent
-# invocations skip this step.
+# downloaded or built and cached under SYMFONION_HOME/lib/symfonion/.
+# Using a sub-directory avoids conflicts when symfonion is unpacked into a
+# shared prefix (e.g. ~/.local) whose lib/ already contains other tools.
+# Subsequent invocations skip installation.
 #
 # Input pipeline for .yaml / .yml files:
 #   yq -o=json <file>  |  jq++  >  <tmp>.json  →  symfonion JAR
@@ -113,27 +115,27 @@ function main() {
   local _symfonion_home
   _symfonion_home="$(realpath "${_scriptdir}/..")"
   local _lib="${_symfonion_home}/lib"
+  local _tools="${_lib}/symfonion"
 
   export JF_PATH
   JF_PATH="$(_build_jf_path "${_symfonion_home}")"
 
-  _ensure_deps "${_lib}"
+  _ensure_deps "${_tools}"
 
   # Preprocess .yaml / .yml arguments: convert YAML → JSON via yq, then
   # resolve jq++ directives ($extends, $includes, etc.) via jq++.
   local -a _args=()
-  local _arg _tmp
+  local _arg _yq_tmp _tmp
   for _arg in "${@}"; do
     if [[ "${_arg}" =~ \.(yaml|yml)$ ]] && [[ -f "${_arg}" ]]; then
       # Two temp files: yq writes JSON to the first; jq++ reads it by path
       # (passing a file argument avoids the no-args symlink-creation branch
       # that jq++ enters when invoked without positional arguments).
-      local _yq_tmp _tmp
       _yq_tmp="$(mktemp /tmp/symfonion-yq-XXXXXX.json)"
       _tmp="$(mktemp /tmp/symfonion-XXXXXX.json)"
       symfonion_cleanup_files+=("${_yq_tmp}" "${_tmp}")
-      "${_lib}/yq" -o=json "${_arg}" > "${_yq_tmp}"
-      "${_lib}/jq++" "${_yq_tmp}" > "${_tmp}"
+      "${_tools}/yq" -o=json "${_arg}" > "${_yq_tmp}"
+      "${_tools}/jq++" "${_yq_tmp}" > "${_tmp}"
       _args+=("${_tmp}")
     else
       _args+=("${_arg}")
@@ -143,9 +145,9 @@ function main() {
   if [[ ${#symfonion_cleanup_files[@]} -gt 0 ]]; then
     # Cannot use exec: the EXIT trap must fire to remove temp files.
     trap 'rm -f "${symfonion_cleanup_files[@]}"' EXIT
-    java -jar "${_symfonion_home}/lib/symfonion.jar" "${_args[@]}"
+    java -jar "${_lib}/symfonion.jar" "${_args[@]}"
   else
-    exec java -jar "${_symfonion_home}/lib/symfonion.jar" "${_args[@]}"
+    exec java -jar "${_lib}/symfonion.jar" "${_args[@]}"
   fi
 }
 

--- a/src/main/resources/utils/symfonion
+++ b/src/main/resources/utils/symfonion
@@ -1,12 +1,30 @@
 #!/usr/bin/env bash
 # symfonion — CLI launcher for SyMFONION (development / unversioned build)
 #
+# On the first invocation, companion tools (yq, jqplusplus / jq++) are
+# downloaded or built and cached under SYMFONION_HOME/lib/.  Subsequent
+# invocations skip this step.
+#
+# Input pipeline for .yaml / .yml files:
+#   yq -o=json <file>  |  jq++  >  <tmp>.json  →  symfonion JAR
+# Plain .json files are passed directly to the JAR.
+#
 # JF_PATH precedence (highest → lowest):
 #   1. User-specified paths  — $SYMFONION_PATH set before invoking symfonion
 #   2. Project-local paths   — .symfonion/prelude in the current working directory
 #   3. Built-in prelude      — $SYMFONION_HOME/share/symfonion/prelude
 
 set -eu -o pipefail -o errtrace
+
+# Version pins for companion tools installed on first use.
+# Bump these when releasing a new symfonion version.
+yq_version="4.44.3"
+jqplusplus_version="latest"
+
+# Temp files created during YAML preprocessing; populated inside main,
+# referenced from the EXIT trap (must be global — local vars are out of
+# scope by the time the EXIT trap fires).
+symfonion_cleanup_files=()
 
 # --- definitions ---
 
@@ -34,16 +52,101 @@ function _build_jf_path() {
   printf '%s' "${_path}"
 }
 
+function _detect_platform() {
+  local _os _arch
+  case "$(uname -s)" in
+    Linux)  _os="linux"  ;;
+    Darwin) _os="darwin" ;;
+    *)
+      printf 'symfonion: unsupported OS: %s\n' "$(uname -s)" >&2
+      return 1
+      ;;
+  esac
+  case "$(uname -m)" in
+    x86_64)        _arch="amd64" ;;
+    arm64|aarch64) _arch="arm64" ;;
+    *)
+      printf 'symfonion: unsupported architecture: %s\n' "$(uname -m)" >&2
+      return 1
+      ;;
+  esac
+  printf '%s_%s' "${_os}" "${_arch}"
+}
+
+function _install_yq() {
+  local _dest="${1}"
+  local _platform
+  _platform="$(_detect_platform)"
+  printf 'symfonion: installing yq %s for %s ...\n' "${yq_version}" "${_platform}" >&2
+  curl -fsSL \
+    "https://github.com/mikefarah/yq/releases/download/v${yq_version}/yq_${_platform}" \
+    -o "${_dest}"
+  chmod +x "${_dest}"
+  printf 'symfonion: yq installed at %s\n' "${_dest}" >&2
+}
+
+function _install_jqplusplus() {
+  local _lib="${1}"
+  printf 'symfonion: installing jqplusplus (%s) ...\n' "${jqplusplus_version}" >&2
+  command -v go >/dev/null 2>&1 || {
+    printf 'symfonion: error: jqplusplus requires the Go toolchain.\n' >&2
+    printf '  Install Go from https://go.dev/dl/ then re-run symfonion.\n' >&2
+    return 1
+  }
+  go install "github.com/dakusui/jqplusplus/cmd/jqplusplus@${jqplusplus_version}"
+  cp "$(go env GOPATH)/bin/jqplusplus" "${_lib}/jqplusplus"
+  chmod +x "${_lib}/jqplusplus"
+  # Invoking jqplusplus with no arguments creates the jq++ symlink next to it.
+  "${_lib}/jqplusplus"
+  printf 'symfonion: jqplusplus installed at %s\n' "${_lib}/jq++" >&2
+}
+
+function _ensure_deps() {
+  local _lib="${1}"
+  [[ -x "${_lib}/yq" ]]   || _install_yq "${_lib}/yq"
+  [[ -x "${_lib}/jq++" ]] || _install_jqplusplus "${_lib}"
+}
+
 function main() {
   local _scriptdir
   _scriptdir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
   local _symfonion_home
   _symfonion_home="$(realpath "${_scriptdir}/..")"
+  local _lib="${_symfonion_home}/lib"
 
   export JF_PATH
   JF_PATH="$(_build_jf_path "${_symfonion_home}")"
 
-  exec java -jar "${_symfonion_home}/lib/symfonion.jar" "${@}"
+  _ensure_deps "${_lib}"
+
+  # Preprocess .yaml / .yml arguments: convert YAML → JSON via yq, then
+  # resolve jq++ directives ($extends, $includes, etc.) via jq++.
+  local -a _args=()
+  local _arg _tmp
+  for _arg in "${@}"; do
+    if [[ "${_arg}" =~ \.(yaml|yml)$ ]] && [[ -f "${_arg}" ]]; then
+      # Two temp files: yq writes JSON to the first; jq++ reads it by path
+      # (passing a file argument avoids the no-args symlink-creation branch
+      # that jq++ enters when invoked without positional arguments).
+      local _yq_tmp _tmp
+      _yq_tmp="$(mktemp /tmp/symfonion-yq-XXXXXX.json)"
+      _tmp="$(mktemp /tmp/symfonion-XXXXXX.json)"
+      symfonion_cleanup_files+=("${_yq_tmp}" "${_tmp}")
+      "${_lib}/yq" -o=json "${_arg}" > "${_yq_tmp}"
+      "${_lib}/jq++" "${_yq_tmp}" > "${_tmp}"
+      _args+=("${_tmp}")
+    else
+      _args+=("${_arg}")
+    fi
+  done
+
+  if [[ ${#symfonion_cleanup_files[@]} -gt 0 ]]; then
+    # Cannot use exec: the EXIT trap must fire to remove temp files.
+    trap 'rm -f "${symfonion_cleanup_files[@]}"' EXIT
+    java -jar "${_symfonion_home}/lib/symfonion.jar" "${_args[@]}"
+  else
+    exec java -jar "${_symfonion_home}/lib/symfonion.jar" "${_args[@]}"
+  fi
 }
 
 # --- entry point ---

--- a/src/site/asciidoc/CLI.adoc
+++ b/src/site/asciidoc/CLI.adoc
@@ -17,6 +17,8 @@
 
 SyMFONION is a music macro language processor whose syntax is based on JSON. It provides a way to describe music works in a structured and object oriented way.
 
+NOTE: **YAML is the recommended input format.** The `symfonion` launcher transparently converts `.yaml` / `.yml` files to JSON and runs them through `jq++` before passing them to the processor. Because YAML is a strict superset of JSON, every JSON example in this documentation and in link:SYNTAX.html[the Syntax reference] is also valid YAML. You can write symfonion files as plain JSON, YAML, or YAML with `jq++` inheritance directives (`$extends`, `$includes`) — the launcher handles all three.
+
 When invoked without specifying any output files, it simply plays the input file(s).
 
 This page documents the command-line arguments for the SyMFONION processor.

--- a/src/site/asciidoc/CLI.adoc
+++ b/src/site/asciidoc/CLI.adoc
@@ -88,6 +88,7 @@ Written by Hiroshi Ukai
 == See also
 
 // suppress inspection "AsciiDocLinkResolve"
+* link:INSTALLATION.html[Installation &amp; directory layout]
 * link:SYNTAX.html[Syntax of SyMFONION]
 * JSON : http://www.json.org/
 * MIDI standard: http://www.midi.org/aboutmidi/ , http://en.wikipedia.org/wiki/MIDI

--- a/src/site/asciidoc/INSTALLATION.adoc
+++ b/src/site/asciidoc/INSTALLATION.adoc
@@ -9,13 +9,18 @@ The archive unpacks to a versioned, self-contained directory:
 ----
 symfonion-VERSION/
   bin/
-    symfonion                 ← CLI launcher (bash script)
+    symfonion                    ← CLI launcher (bash script)
   lib/
-    symfonion-VERSION.jar     ← Java core
+    symfonion-VERSION.jar        ← Java core
+    symfonion/                   ← companion tools (populated on first run; see below)
   share/
     symfonion/
-      prelude/                ← built-in jq++ standard library
+      prelude/                   ← built-in jq++ standard library
 ----
+
+The companion tools are kept under `lib/symfonion/` rather than directly in `lib/`
+so that installing into a shared prefix (e.g. `~/.local` or `/usr/local`) does not
+conflict with other software that places files in that `lib/` directory.
 
 Add `symfonion-VERSION/bin/` to your `PATH` and you are done.
 
@@ -29,11 +34,12 @@ for `jqplusplus`, the https://go.dev/dl/[Go toolchain] on your `PATH`.
 ----
 symfonion-VERSION/
   lib/
-    yq                        ← YAML→JSON converter
+    symfonion/
+      yq                      ← YAML→JSON converter
                                 downloaded from github.com/mikefarah/yq releases
-    jqplusplus                ← jq++ binary
+      jqplusplus              ← jq++ binary
                                 installed via: go install github.com/dakusui/jqplusplus/...
-    jq++                      ← symlink → jqplusplus
+      jq++                    ← symlink → jqplusplus
                                 created by jqplusplus on its first invocation
 ----
 

--- a/src/site/asciidoc/INSTALLATION.adoc
+++ b/src/site/asciidoc/INSTALLATION.adoc
@@ -1,0 +1,79 @@
+= symfonion — Installation & Directory Layout
+
+== Distribution archive
+
+Download `symfonion-VERSION-bin.zip` from the
+https://github.com/dakusui/symfonion/releases/[releases page] and unzip it.
+The archive unpacks to a versioned, self-contained directory:
+
+----
+symfonion-VERSION/
+  bin/
+    symfonion                 ← CLI launcher (bash script)
+  lib/
+    symfonion-VERSION.jar     ← Java core
+  share/
+    symfonion/
+      prelude/                ← built-in jq++ standard library
+----
+
+Add `symfonion-VERSION/bin/` to your `PATH` and you are done.
+
+== First-run bootstrap
+
+On the first invocation the launcher automatically downloads and installs
+two companion tools into `lib/`.
+No manual setup is required beyond having an internet connection and,
+for `jqplusplus`, the https://go.dev/dl/[Go toolchain] on your `PATH`.
+
+----
+symfonion-VERSION/
+  lib/
+    yq                        ← YAML→JSON converter
+                                downloaded from github.com/mikefarah/yq releases
+    jqplusplus                ← jq++ binary
+                                installed via: go install github.com/dakusui/jqplusplus/...
+    jq++                      ← symlink → jqplusplus
+                                created by jqplusplus on its first invocation
+----
+
+Subsequent invocations detect the cached binaries and skip installation.
+
+== Project-local library path (optional)
+
+Place jq++ library files (YAML++ snippets shared across songs in a project)
+in a `.symfonion/prelude/` directory alongside your song files.
+The launcher adds this directory to `JF_PATH` automatically.
+
+----
+my-project/
+  .symfonion/
+    prelude/                  ← project-local jq++ library
+  song1.yaml
+  song2.yaml
+----
+
+== JF_PATH precedence
+
+`JF_PATH` is the search path used by `jq++` to resolve `$extends` and
+`$includes` references.  The launcher builds it in this order
+(highest priority first):
+
+[cols="1,3"]
+|===
+| Source | Path
+
+| `$SYMFONION_PATH` env var
+| Set this before invoking symfonion to prepend your own library directories.
+
+| `.symfonion/prelude/`
+| Project-local overrides, resolved relative to the current working directory.
+
+| `share/symfonion/prelude/`
+| Built-in standard library shipped with the distribution.
+|===
+
+== See also
+
+* link:CLI.html[Command-line reference]
+* link:SYNTAX.html[Symfonion language syntax]

--- a/src/site/asciidoc/SYNTAX.adoc
+++ b/src/site/asciidoc/SYNTAX.adoc
@@ -6,7 +6,30 @@
 
 "symfonion" is a JSON-based music macro language, which enables you to describe a piece of music as easily as 8-bit days' MML but in a much more structured way.
 
-Here is an example piece of music written in symfonion.
+NOTE: **YAML is the recommended input format.** The `symfonion` launcher transparently converts `.yaml` / `.yml` files to JSON before passing them to the processor. Because YAML is a strict superset of JSON, every JSON example in this document is also valid YAML and can be written in YAML style instead. The YAML form is generally more readable: it requires no quotes around most strings, allows comments (`#`), and avoids the syntactic noise of JSON. Where it helps, this document shows both forms side by side.
+
+Here is an example piece of music written in symfonion. First in **YAML** (recommended), then the equivalent **JSON**:
+
+[source, yaml]
+----
+parts:
+  testviolin:
+    channel: 0
+
+sequence:
+  - beats: "8/8"
+    parts:
+      - name: testviolin
+        body: "C2;C2"
+        length: "8"
+  - beats: "8/8"
+    parts:
+      - name: testviolin
+        body: "C2;C2"
+        length: "8"
+----
+
+The equivalent JSON form (also accepted):
 
 [source, json]
 ----

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -3,6 +3,7 @@
         <menu name="Documents">
             <item href="SYNTAX.html" name="About symfonion syntax"/>
             <item href="CLI.html" name="About symfonion CLI"/>
+            <item href="INSTALLATION.html" name="Installation &amp; directory layout"/>
         </menu>
         <menu ref="reports" inherit="top"/>
         <menu ref="modules"/>


### PR DESCRIPTION
## Summary

- `bin/symfonion` now accepts `.yaml` / `.yml` input files and transparently preprocesses them through `yq` (YAML→JSON) then `jq++` (`$extends`/`$includes` resolution) before passing the result to the JAR
- On first invocation, the launcher auto-installs `yq` (pre-built binary from GitHub releases) and `jqplusplus` (via `go install`) into `$SYMFONION_HOME/lib/` — no manual setup needed; subsequent runs use the cached binaries
- Plain `.json` files bypass preprocessing entirely — full backward compatibility
- `jq++` symlink is created by invoking `jqplusplus` with no arguments, following its own bootstrap convention
- Fix for SIGPIPE (exit 141): `jq++` invoked with no positional args enters symlink-creation mode (due to `os.Executable()` resolving the symlink back to `jqplusplus`); fixed by writing `yq` output to a temp file and passing it as a positional arg to `jq++`

## Documentation

- `README.md` — YAML version of the Mozart K.311 example as the primary form, JSON kept as reference
- `SYNTAX.adoc` — NOTE box + YAML/JSON side-by-side opening example
- `CLI.adoc` — NOTE box explaining YAML as the recommended format
- `AGENTS.md` — new "Launcher & Preprocessing Pipeline" section

## Test plan

- [x] `bin/symfonion -p song.yaml` — YAML file preprocessed and played
- [x] `bin/symfonion -p song.json` — plain JSON still works unchanged
- [x] First run with empty `lib/` — `yq` and `jqplusplus` installed automatically
- [x] Subsequent run — no reinstall, cached binaries used
- [x] `mvn -B test` passes (no Java changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)