### PR TITLE
feat: print now-playing measure info during MIDI playback

### DIFF
--- a/src/main/java/com/github/dakusui/symfonion/cli/subcommands/Play.java
+++ b/src/main/java/com/github/dakusui/symfonion/cli/subcommands/Play.java
@@ -13,6 +13,7 @@ import javax.sound.midi.*;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.function.Function;
 import java.util.regex.Pattern;
@@ -34,7 +35,7 @@ public class Play implements Subcommand {
       ps.println();
       Map<String, MidiDevice> midiOutDevices = prepareMidiOutDevices(ps, cli.midiOutRegexPatterns());
       ps.println();
-      play(midiOutDevices, sequences);
+      play(ps, midiOutDevices, sequences);
     }
   }
 
@@ -58,13 +59,13 @@ public class Play implements Subcommand {
     return devices;
   }
 
-  private static Map<String, Sequencer> prepareSequencers(List<String> portNames, Map<String, MidiDevice> midiOutDevices, Map<String, Sequence> sequences) throws MidiUnavailableException, InvalidMidiDataException {
+  private static Map<String, Sequencer> prepareSequencers(List<String> portNames, Map<String, MidiDevice> midiOutDevices, Map<String, Sequence> sequences, PrintStream ps) throws MidiUnavailableException, InvalidMidiDataException {
     Map<String, Sequencer> ret               = new HashMap<>();
     final List<Sequencer>  playingSequencers = new LinkedList<>();
     for (String portName : portNames) {
       MidiDevice      midiOutDevice = midiOutDevices.get(portName);
       Sequence        sequence      = sequences.get(portName);
-      final Sequencer sequencer     = prepareSequencer(midiOutDevice, sequence, seq -> createMetaEventListener(playingSequencers, seq));
+      final Sequencer sequencer     = prepareSequencer(midiOutDevice, sequence, seq -> createMetaEventListener(playingSequencers, seq, ps));
       playingSequencers.add(sequencer);
       ret.put(portName, sequencer);
     }
@@ -94,13 +95,15 @@ public class Play implements Subcommand {
     sequencer.getTransmitter().setReceiver(dev.getReceiver());
   }
 
-  private static MetaEventListener createMetaEventListener(List<Sequencer> playingSequencers, Sequencer sequencer) {
+  private static MetaEventListener createMetaEventListener(List<Sequencer> playingSequencers, Sequencer sequencer, PrintStream ps) {
     return new MetaEventListener() {
       final Sequencer seq = sequencer;
 
       @Override
       public void meta(MetaMessage meta) {
-        if (meta.getType() == 0x2f) {
+        if (meta.getType() == 0x06) {
+          ps.println(new String(meta.getData(), StandardCharsets.UTF_8));
+        } else if (meta.getType() == 0x2f) {
           synchronized (Play.class) {
             try {
               Thread.sleep(1000);
@@ -139,11 +142,11 @@ public class Play implements Subcommand {
     }
   }
 
-  static synchronized void play(Map<String, MidiDevice> midiOutDevices, Map<String, Sequence> sequences) throws SymfonionException {
+  static synchronized void play(PrintStream ps, Map<String, MidiDevice> midiOutDevices, Map<String, Sequence> sequences) throws SymfonionException {
     List<String>           portNames = new LinkedList<>(sequences.keySet());
     Map<String, Sequencer> sequencers;
     try {
-      sequencers = prepareSequencers(portNames, midiOutDevices, sequences);
+      sequencers = prepareSequencers(portNames, midiOutDevices, sequences, ps);
       try {
         startSequencers(portNames, sequencers);
         Play.class.wait();

--- a/src/main/java/com/github/dakusui/symfonion/cli/subcommands/PlaySong.java
+++ b/src/main/java/com/github/dakusui/symfonion/cli/subcommands/PlaySong.java
@@ -31,7 +31,7 @@ public class PlaySong implements Subcommand {
       ps.println();
       Map<String, MidiDevice> midiOutDevices = prepareMidiOutDevices(ps, cli.midiOutRegexPatterns());
       ps.println();
-      play(midiOutDevices, sequences);
+      play(ps, midiOutDevices, sequences);
     }
   }
 }

--- a/src/main/java/com/github/dakusui/symfonion/core/MidiCompiler.java
+++ b/src/main/java/com/github/dakusui/symfonion/core/MidiCompiler.java
@@ -14,6 +14,7 @@ import com.google.gson.JsonArray;
 import javax.sound.midi.*;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -58,6 +59,8 @@ public class MidiCompiler {
       tracks.put(partName, sequence.createTrack());
     }
 
+    Track markerTrack = ret.isEmpty() ? null : ret.values().iterator().next().createTrack();
+
     ////
     // position is the offset of a bar from the beginning of the sequence.
     // Giving the sequencer a grace period to initialize its internal state.
@@ -67,6 +70,18 @@ public class MidiCompiler {
     for (Measure measure : song.measures()) {
       try (var ignored = exceptionContext(entry(JSON_ELEMENT_ROOT, value))) {
         barStarted(measureId);
+        if (markerTrack != null) {
+          try {
+            String labelPart = measure.labels().isEmpty()
+                ? ""
+                : " {" + String.join(", ", measure.labels()) + "}";
+            String partsPart = String.join(", ", measure.activePartNames());
+            markerTrack.add(createMeasureMarkerEvent(
+                String.format("[bar %3d]%s - %s", measureId, labelPart, partsPart),
+                barPositionInTicks));
+          } catch (InvalidMidiDataException ignored2) {
+          }
+        }
         Groove groove = measure.groove();
         for (String partName : measure.activePartNames()) {
           var         track       = getTrack(partName, tracks);
@@ -139,6 +154,8 @@ public class MidiCompiler {
       tracks.put(partName, sequence.createTrack());
     }
 
+    Track markerTrack = ret.isEmpty() ? null : ret.values().iterator().next().createTrack();
+
     ////
     // position is the offset of a bar from the beginning of the sequence.
     // Giving the sequencer a grace period to initialize its internal state.
@@ -148,6 +165,18 @@ public class MidiCompiler {
     for (Bar bar : song.bars()) {
       try (var ignored = exceptionContext(entry(JSON_ELEMENT_ROOT, value))) {
         barStarted(barid);
+        if (markerTrack != null) {
+          try {
+            String labelPart = bar.labels().isEmpty()
+                ? ""
+                : " {" + String.join(", ", bar.labels()) + "}";
+            String partsPart = String.join(", ", bar.partNames());
+            markerTrack.add(createMeasureMarkerEvent(
+                String.format("[bar %3d]%s - %s", barid, labelPart, partsPart),
+                barPositionInTicks));
+          } catch (InvalidMidiDataException ignored2) {
+          }
+        }
         Groove groove = bar.groove();
         for (String partName : bar.partNames()) {
           partStarted(partName);
@@ -316,6 +345,13 @@ public class MidiCompiler {
     byte[]      data = Utils.getIntBytes(mpqn);
     mm.setMessage(0x51, data, data.length);
     return new MidiEvent(mm, lTick);
+  }
+
+  public MidiEvent createMeasureMarkerEvent(String text, long tick) throws InvalidMidiDataException {
+    MetaMessage mm   = new MetaMessage();
+    byte[]      data = text.getBytes(StandardCharsets.UTF_8);
+    mm.setMessage(0x06, data, data.length);
+    return new MidiEvent(mm, tick);
   }
 
   public void noteProcessed() {

--- a/src/site/asciidoc/CLI.adoc
+++ b/src/site/asciidoc/CLI.adoc
@@ -41,6 +41,67 @@ Lists the available MIDI input and output devices.
 Plays the specified file.
 See also '-O' option.
 
+During playback, a progress line is printed to standard output each time a new measure begins.
+
+Given a YAML file like this:
+
+[source, yaml]
+----
+parts:
+  piano:
+    channel: 0
+  bass:
+    channel: 1
+
+sequence:
+  - beats: 4/4
+    labels: [intro]
+    parts:
+      - name: piano
+        body: C4;E4;G4;C>4
+      - name: bass
+        body: C3;r4;r4;r4
+
+  - beats: 4/4
+    labels: [verse]
+    parts:
+      - name: piano
+        body: F4;A4;C>4;r4
+      - name: bass
+        body: F3;r4;r4;r4
+
+  - beats: 4/4
+    labels: [verse]
+    parts:
+      - name: piano
+        body: G4;B4;D>4;r4
+      - name: bass
+        body: G3;r4;r4;r4
+----
+
+Playing it produces:
+
+.Console
+----
+user@host:~/work $ symfonion -p song.yaml
+Start playing on port1(1719820123456)
+[bar   0] {intro} - piano, bass
+[bar   1] {verse} - piano, bass
+[bar   2] {verse} - piano, bass
+Finished playing.
+----
+
+`[bar N]` is the zero-based index of the measure in the `sequence` array of the input file.
+The `{label, ...}` section appears only when the measure has a `labels` field — these strings are defined by the user and are directly searchable in the YAML.
+The part names after ` - ` are the keys from the `parts` section that are active in that measure.
+Measures without `labels` print without the `{...}` section:
+
+----
+[bar   0] - piano, bass
+----
+
+This output makes it easy to correlate what you hear with the corresponding measure in the source file: search for a label name, or count to index `N` in the `sequence` array.
+
 === --compile or -c
 Compiles the specified file to a standard MIDI file.
 The example command line below compiles the input file 'example2.js' and output the compiled midi file to 'test.mid'.

--- a/src/test/java/com/github/dakusui/symfonion/tests/MidiCompilerTest.java
+++ b/src/test/java/com/github/dakusui/symfonion/tests/MidiCompilerTest.java
@@ -94,7 +94,7 @@ public class MidiCompilerTest extends TestBase {
                     FromList.<String>toElementAt(0).isEqualTo("port1")),
                 Transform.$(FromSong.toSequence("port1")).allOf(
                     Transform.$(trackList()).allOf(
-                        FromList.toSize().isEqualTo(1),
+                        FromList.toSize().isEqualTo(2),
                         FromList.<Track>toElementAt(0).allOf(
                             Transform.$(size()).isEqualTo(1),
                             Transform.$(midiEventAt(0)).isNotNull(),
@@ -119,7 +119,7 @@ public class MidiCompilerTest extends TestBase {
                     FromList.<String>toElementAt(0).isEqualTo("port1")),
                 Transform.$(FromSong.toSequence("port1")).allOf(
                     Transform.$(trackList()).allOf(
-                        FromList.toSize().isEqualTo(1),
+                        FromList.toSize().isEqualTo(2),
                         FromList.<Track>toElementAt(0).allOf(
                             Transform.$(size()).isEqualTo(6),
                             Transform.$(midiEventAt(0)).isNotNull(),
@@ -145,7 +145,7 @@ public class MidiCompilerTest extends TestBase {
                     FromList.<String>toElementAt(0).isEqualTo("port1")),
                 Transform.$(FromSong.toSequence("port1")).allOf(
                     toListBy(trackList()).allOf(
-                        FromList.toSize().isEqualTo(1),
+                        FromList.toSize().isEqualTo(2),
                         FromList.<Track>toElementAt(0).allOf(
                             Transform.$(size()).isEqualTo(33),
                             Transform.$(midiEventAt(0)).isNotNull(),
@@ -162,7 +162,7 @@ public class MidiCompilerTest extends TestBase {
                     FromList.toSize().isEqualTo(1),
                     FromList.<String>toElementAt(0).isEqualTo("port1")),
                 Transform.$(FromSong.toSequence("port1").andThen(trackList())).allOf(
-                    FromList.toSize().isEqualTo(1),
+                    FromList.toSize().isEqualTo(2),
                     FromList.<Track>toElementAt(0).allOf(
                         Transform.$(size()).isEqualTo(33),
                         Transform.$(midiEventAt(0)).isNotNull(),
@@ -177,7 +177,7 @@ public class MidiCompilerTest extends TestBase {
                     FromList.toSize().isEqualTo(1),
                     FromList.<String>toElementAt(0).isEqualTo("port1")),
                 Transform.$(FromSong.toSequence("port1").andThen(trackList())).allOf(
-                    FromList.toSize().isEqualTo(1),
+                    FromList.toSize().isEqualTo(2),
                     FromList.<Track>toElementAt(0).allOf(
                         Transform.$(size()).isEqualTo(33),
                         Transform.$(midiEventAt(0)).isNotNull(),
@@ -192,7 +192,7 @@ public class MidiCompilerTest extends TestBase {
                     FromList.toSize().isEqualTo(1),
                     FromList.<String>toElementAt(0).isEqualTo("port1")),
                 Transform.$(FromSong.toSequence("port1").andThen(trackList())).allOf(
-                    FromList.toSize().isEqualTo(1),
+                    FromList.toSize().isEqualTo(2),
                     FromList.<Track>toElementAt(0).allOf(
                         Transform.$(size()).isEqualTo(4),
                         Transform.$(midiEventAt(0)).isNotNull(),


### PR DESCRIPTION
## Summary

- Embeds MIDI Marker meta events (type `0x06`) into the compiled sequence at the tick position where each measure starts
- The `MetaEventListener` in `Play` fires them in real time and prints a line per measure, e.g.:
  ```
  [bar   2] {chorus} - piano, guitar, bass
  ```
- Bar index = zero-based position in the `sequence` array; labels and part names come directly from the YAML source, making each line grep-able
- Documents the feature with a worked YAML example in `CLI.adoc`

## Test plan

- [x] Existing `MidiCompilerTest` suite passes (track-count assertions updated from 1→2 to account for the new dedicated marker track)
- [x] Run `symfonion play-song` on any example file and confirm `[bar N] ...` lines appear in real time during playback
- [x] Add `labels` to a measure in a YAML file and confirm `{label}` appears in the output

🤖 Generated with [Claude Code](https://claude.com/claude-code)