### PR TITLE
fix: route AsciiDoc HTML output to target/site/en/

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -400,7 +400,7 @@
                             </goals>
                             <configuration>
                                 <backend>html5</backend>
-                                <outputDirectory>target/site</outputDirectory>
+                                <outputDirectory>${project.build.directory}/site/en</outputDirectory>
                                 <attributes>
                                     <imagesdir>.</imagesdir>
                                     <toc>left</toc>


### PR DESCRIPTION
## Summary

- `maven-site-plugin` is configured with `<locales>en</locales>`, so all Maven-generated reports go to `target/site/en/`
- The `asciidoctor-maven-plugin` execution had `<outputDirectory>target/site</outputDirectory>` hardcoded, placing `CLI.html`, `SYNTAX.html`, and `INSTALLATION.html` directly under `target/site/` — one level above where the site navigation expects them
- Changed to `${project.build.directory}/site/en` to align with the locale-based layout

## Test plan

- [x] Run `mvn site` and confirm `CLI.html`, `SYNTAX.html`, `INSTALLATION.html` are under `target/site/en/`
- [ ] Confirm no `*.html` files appear directly under `target/site/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)