### PR TITLE
fix: quiet hot recompilation progress

### DIFF
--- a/src/main/java/com/github/dakusui/symfonion/cli/subcommands/Play.java
+++ b/src/main/java/com/github/dakusui/symfonion/cli/subcommands/Play.java
@@ -46,7 +46,7 @@ public class Play implements Subcommand {
             Path jsonTmp = convertYamlToJson(yaml, tools);
             try {
               CompatSong s = symfonion.load(jsonTmp.toString(), cli.barFilter(), cli.partFilter());
-              return symfonion.compile(s, createLogiasContext());
+              return symfonion.compile(s, createLogiasContext(), false);
             } finally {
               Files.deleteIfExists(jsonTmp);
             }
@@ -57,7 +57,7 @@ public class Play implements Subcommand {
       } else {
         recompiler = () -> {
           CompatSong s = symfonion.load(cli.source().getAbsolutePath(), cli.barFilter(), cli.partFilter());
-          return symfonion.compile(s, createLogiasContext());
+          return symfonion.compile(s, createLogiasContext(), false);
         };
       }
       ps.println();

--- a/src/main/java/com/github/dakusui/symfonion/cli/subcommands/PlaySong.java
+++ b/src/main/java/com/github/dakusui/symfonion/cli/subcommands/PlaySong.java
@@ -41,7 +41,7 @@ public class PlaySong implements Subcommand {
             Path jsonTmp = Play.convertYamlToJson(yaml, tools);
             try {
               Song s = symfonion.loadSong(jsonTmp.toString(), cli.measureFilter(), cli.partFilter());
-              return symfonion.compileSong(s, createLogiasContext());
+              return symfonion.compileSong(s, createLogiasContext(), false);
             } finally {
               Files.deleteIfExists(jsonTmp);
             }
@@ -52,7 +52,7 @@ public class PlaySong implements Subcommand {
       } else {
         recompiler = () -> {
           Song s = symfonion.loadSong(cli.source().getAbsolutePath(), cli.measureFilter(), cli.partFilter());
-          return symfonion.compileSong(s, createLogiasContext());
+          return symfonion.compileSong(s, createLogiasContext(), false);
         };
       }
       ps.println();

--- a/src/main/java/com/github/dakusui/symfonion/core/MidiCompiler.java
+++ b/src/main/java/com/github/dakusui/symfonion/core/MidiCompiler.java
@@ -30,6 +30,7 @@ import static com.github.dakusui.symfonion.compat.exceptions.ExceptionContext.en
 public class MidiCompiler {
 
   private final Context logiasContext;
+  private final boolean progressEnabled;
 
   /**
    * Creates an object of this class.
@@ -39,11 +40,16 @@ public class MidiCompiler {
    * @see Context
    */
   public MidiCompiler(Context logiasContext) {
-    this.logiasContext = (logiasContext);
+    this(logiasContext, true);
+  }
+
+  public MidiCompiler(Context logiasContext, boolean progressEnabled) {
+    this.logiasContext     = logiasContext;
+    this.progressEnabled   = progressEnabled;
   }
 
   public Map<String, Sequence> compile(Song song) throws InvalidMidiDataException {
-    System.err.println("Now compiling...");
+    compilationStarted();
     int                   resolution = 384;
     Map<String, Sequence> ret        = new HashMap<>();
     Map<String, Track>    tracks;
@@ -114,9 +120,7 @@ public class MidiCompiler {
         barPositionInTicks += (long) (measure.beats().doubleValue() * resolution);
       }
     }
-    System.err.
-
-        println("Compilation finished.");
+    compilationFinished();
     return ret;
   }
 
@@ -138,7 +142,7 @@ public class MidiCompiler {
    * @throws SymfonionException       Undefined part name is referenced by a bar.
    */
   public Map<String, Sequence> compile(CompatSong song) throws InvalidMidiDataException, SymfonionException {
-    System.err.println("Now compiling...");
+    compilationStarted();
     int                   resolution = 384;
     Map<String, Sequence> ret        = new HashMap<>();
     Map<String, Track>    tracks;
@@ -221,7 +225,7 @@ public class MidiCompiler {
         barPositionInTicks += (long) (bar.beats().doubleValue() * resolution);
       }
     }
-    System.err.println("Compilation finished.");
+    compilationFinished();
     return ret;
   }
 
@@ -355,26 +359,32 @@ public class MidiCompiler {
   }
 
   public void noteProcessed() {
+    if (!progressEnabled) return;
     System.out.print(".");
   }
 
   public void controlEventProcessed() {
+    if (!progressEnabled) return;
     System.out.print("*");
   }
 
   public void sysexEventProcessed() {
+    if (!progressEnabled) return;
     System.out.print("X");
   }
 
   public void barStarted(int barid) {
+    if (!progressEnabled) return;
     System.out.println("bar[" + barid + "]");
   }
 
   public void patternStarted() {
+    if (!progressEnabled) return;
     System.out.print("[");
   }
 
   public void patternEnded() {
+    if (!progressEnabled) return;
     System.out.print("]");
   }
 
@@ -382,22 +392,37 @@ public class MidiCompiler {
   }
 
   public void partStarted(String partName) {
+    if (!progressEnabled) return;
     System.out.print("    " + partName + ":");
   }
 
   public void partMeasureEnded() {
+    if (!progressEnabled) return;
     System.out.print("|");
   }
 
   public void partEnded() {
+    if (!progressEnabled) return;
     System.out.println();
   }
 
   public void aborted() {
+    if (!progressEnabled) return;
     System.out.println("aborted.");
   }
 
   public void noteSetProcessed() {
+    if (!progressEnabled) return;
     System.out.print(";");
+  }
+
+  private void compilationStarted() {
+    if (!progressEnabled) return;
+    System.err.println("Now compiling...");
+  }
+
+  private void compilationFinished() {
+    if (!progressEnabled) return;
+    System.err.println("Compilation finished.");
   }
 }

--- a/src/main/java/com/github/dakusui/symfonion/core/Symfonion.java
+++ b/src/main/java/com/github/dakusui/symfonion/core/Symfonion.java
@@ -102,7 +102,12 @@ public class Symfonion {
    */
   @Deprecated
   public Map<String, Sequence> compile(CompatSong song, Context logiasContext) {
-    MidiCompiler          compiler = new MidiCompiler(loadMidiDeviceProfile(song.rootJsonObject(), logiasContext));
+    return compile(song, logiasContext, true);
+  }
+
+  @Deprecated
+  public Map<String, Sequence> compile(CompatSong song, Context logiasContext, boolean progressEnabled) {
+    MidiCompiler          compiler = new MidiCompiler(loadMidiDeviceProfile(song.rootJsonObject(), logiasContext), progressEnabled);
     Map<String, Sequence> ret;
     try {
       ret = compiler.compile(song);
@@ -120,7 +125,11 @@ public class Symfonion {
    * @return A map from part name to a MIDI sequence object.
    */
   public Map<String, Sequence> compileSong(Song song, Context logiasContext) {
-    MidiCompiler          compiler = new MidiCompiler(loadMidiDeviceProfile(song.rootJsonObject(), logiasContext));
+    return compileSong(song, logiasContext, true);
+  }
+
+  public Map<String, Sequence> compileSong(Song song, Context logiasContext, boolean progressEnabled) {
+    MidiCompiler          compiler = new MidiCompiler(loadMidiDeviceProfile(song.rootJsonObject(), logiasContext), progressEnabled);
     Map<String, Sequence> ret;
     try {
       ret = compiler.compile(song);


### PR DESCRIPTION
## Summary
- add progress control to MidiCompiler while keeping verbose compilation as the default
- use quiet compilation for Enter-triggered play-mode recompilation in both legacy and current song paths

## Tests
- mvn -B test
- mvn -B package